### PR TITLE
关于文章中的计数实例

### DIFF
--- a/word_count.ipynb
+++ b/word_count.ipynb
@@ -4026,3 +4026,4 @@
  "nbformat": 4,
  "nbformat_minor": 2
 }
+END


### PR DESCRIPTION
如何给文章中的单词进行计数的实例，两种方法。包括字典，列表，和元组的使用。另一种是 使用collections包里的Counter计数功能直接计数。